### PR TITLE
Use npm ci when a package-lock.json exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,11 @@ else
     if [ -f yarn.lock ]; then
         setup="yarn --non-interactive --silent --ignore-scripts --production=false &&"
     else
-        setup="NODE_ENV=development npm install &&"
+        if [ -f package-lock.json ]; then
+            setup="NODE_ENV=development npm ci --ignore-scripts &&"
+        else
+            setup="NODE_ENV=development npm install --no-package-lock --ignore-scripts &&"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Use `npm ci` instead of `npm install` when a `package-lock.json` file exists. Both for performance reasons and to run the exact version of `eslint` as specified in the repo.

It also adds `--ignore-scripts` to both `npm` calls to bring it in line with `yarn` and it adds `--no-package-lock` to `npm install` to keep it from creating a `package-lock.json` which wasn't there before.