### PR TITLE
Use actions/checkout@v3 insted of v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install modules
       run: yarn
     - name: Run ESLint


### PR DESCRIPTION
This is for avoid github warnings when running the workflow.